### PR TITLE
Query History - Run Button

### DIFF
--- a/src/Query/QueryHistory.tsx
+++ b/src/Query/QueryHistory.tsx
@@ -6,6 +6,7 @@ import "@rmwc/icon/icon.css";
 import { Query, languageOptions } from "../queries";
 import "./QueryHistory.css";
 import { useQueryHistory } from "./query-history-service";
+import RunButton from "../RunButton";
 
 type OnRecovery = (query: Query) => void;
 
@@ -51,6 +52,9 @@ const QueryHistoryItem = ({
       </div>
       <div className="language">{option && option.label}</div>
       <div className="query">{query.text}</div>
+      <div className="actions">
+          <RunButton onClick={run} />
+      </div>    
     </ListItem>
   );
 };


### PR DESCRIPTION
Using this pull request to see how active this project is and to test if this feature would be desired as well as well as communicating with the main contributor the roadmap to do so. Essentially, I just want to add a button to the query history tab that will rerun that query instead of having to manually type it up (or even just push it to the text editor). How i think this would go is essentially adding this button to QueryHistory.tsx (as shown in this PR). Add a new run function that mimics the run function on QueryPage.tsx but with the query stored in that QueryHistory Item. Thanks 